### PR TITLE
In most cases it makes sense to use fs.watch

### DIFF
--- a/monocle.js
+++ b/monocle.js
@@ -1,7 +1,7 @@
 var path        = require('path');
 var fs          = require('fs');
 var readdirp    = require('readdirp');
-var is_windows  = process.platform === 'win32';
+var use_fs_watch  = process.platform === 'win32' || process.env.USE_FS_WATCH;
 
 module.exports = function() {
   var watched_files       = {};
@@ -50,7 +50,7 @@ module.exports = function() {
   }
 
   function unwatchAll() {
-    if (is_windows) {
+    if (use_fs_watch) {
       Object.keys(watched_files).forEach(function(key) {
         watched_files[key].close();
       });
@@ -100,7 +100,7 @@ module.exports = function() {
     setAbsolutePath(file);
     storeDirectory(file);
     if (!watched_files[file.fullPath]) {
-      if (is_windows) {
+      if (use_fs_watch) {
         (function() {
           watched_files[file.fullPath] = fs.watch(file.fullPath, function() {
             typeof cb === "function" && cb(file);


### PR DESCRIPTION
see:
http://nodejs.org/docs/latest/api/fs.html#fs_fs_watchfile_filename_options_listener

This feature depends on the underlying operating system providing a way to be notified of filesystem changes.
- On Linux systems, this uses inotify.
- On BSD systems (including OS X), this uses kqueue.
- On SunOS systems (including Solaris and SmartOS), this uses event ports.
- On Windows systems, this feature depends on ReadDirectoryChangesW.

If the underlying functionality is not available for some reason, then fs.watch will not be able to function. For example, watching files or directories on network file systems (NFS, SMB, etc.) often doesn't work reliably or at all.

Basically, this change let's someone decide whether to use the fallback fs.watchFile option based on their environment, since in most non network-filesystem cases people will want to use fs.watch
